### PR TITLE
Fix profiling state

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM python:3.7-slim
 
-RUN pip install taktile-cli==0.3.15
+RUN apt update && apt install jq -y
+
+RUN pip install taktile-cli==0.5.26
 
 COPY run.sh /run.sh
 RUN chmod +x /run.sh
-
-RUN apt update && apt install jq -y
 
 ENTRYPOINT ["/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -9,9 +9,9 @@ COMMIT_SHA=$GITHUB_SHA
 # Check
 tktl login "$TKTL_API_KEY"
 
-while tktl get deployments -c "$COMMIT_SHA" -f -O json | jq '.[].status' | grep -v -q 'running'; do
+while tktl get deployments -c "$COMMIT_SHA" -f -O json | jq '.[].status' | grep -vE -q 'running|profiling'; do
     sleep 2
-    echo 'Waiting for deployment status to be running ...'
+    echo 'Waiting for deployment to be complete (status profiling or running) ...'
 done
 
 echo 'The status is now ...'

--- a/run.sh
+++ b/run.sh
@@ -11,7 +11,7 @@ tktl login "$TKTL_API_KEY"
 
 while tktl get deployments -c "$COMMIT_SHA" -f -O json | jq '.[].status' | grep -vE -q 'running|profiling'; do
     sleep 2
-    echo 'Waiting for deployment to be complete (status profiling or running) ...'
+    echo 'Waiting for deployment to complete (status profiling or running) ...'
 done
 
 echo 'The status is now ...'


### PR DESCRIPTION
Makes the await deployment action complete even when the deployment is still profiling, which is desired behavior. It was behavior before we added profiling as a proper lifecycle state, so this undoes the implicit change of behavior that happened here during that time.