### PR TITLE
feat: deployment commit hash can be passed via env

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -5,11 +5,16 @@ inputs:
   TKTL_API_KEY:
     description: 'Your Taktile API key'
     required: true
+  DEPLOY_SHA:
+    description: 'Long commit hash of the deployment. If not set GITHUB_SHA is used'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.TKTL_API_KEY }}
+    - ${{ inputs.DEPLOY_SHA }}
 branding:
   icon: 'rotate-ccw'
   color: 'green'
+

--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 TKTL_API_KEY=$INPUT_TKTL_API_KEY
 # GITHUB_SHA is the commit hash of the running action and set by github. 
 # DEPLOY_SHA can be set in the github action to watch for a different deployment
-COMMIT_SHA="${DEPLOY_SHA:-$GITHUB_SHA}"
+COMMIT_SHA="${INPUT_DEPLOY_SHA:-$GITHUB_SHA}"
 
 # Check
 tktl login "$TKTL_API_KEY"

--- a/run.sh
+++ b/run.sh
@@ -11,6 +11,7 @@ COMMIT_SHA="${INPUT_DEPLOY_SHA:-$GITHUB_SHA}"
 # Check
 tktl login "$TKTL_API_KEY"
 
+tktl get deployments -c "$COMMIT_SHA" -f -O json > /dev/null || (echo "No deployments with commit hash $COMMIT_SHA" && exit 1)
 while tktl get deployments -c "$COMMIT_SHA" -f -O json | jq '.[].status' | grep -vE -q 'running|profiling'; do
     sleep 2
     echo 'Waiting for deployment to complete (status profiling or running) ...'

--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 
 # inputs given by GitHub action -e docker runtime env vars
 TKTL_API_KEY=$INPUT_TKTL_API_KEY
-COMMIT_SHA=$GITHUB_SHA
+# GITHUB_SHA is the commit hash of the running action and set by github. 
+# DEPLOY_SHA can be set in the github action to watch for a different deployment
+COMMIT_SHA="${DEPLOY_SHA:-$GITHUB_SHA}"
 
 # Check
 tktl login "$TKTL_API_KEY"


### PR DESCRIPTION
the action checks for the commit set in GITHUB_SHA by default.
GITHUB_SHA is the commit on which the action is running.
the user can now check for a different deployment by passing
the deployment hash with the env variable DEPLOY_SHA

Developertest:

Set taktile repo key (used in all tests)
```$ export INPUT_TKTL_API_KEY=bandit_repo_api_key```

1. Non existing deployment, optional variable not set
```$ export GITHUB_SHA=non_existing_sha
$ bash run.sh```
Authentication successful for user: rmminusrslash
No resources found
The status is now ...
No resources found
```
@r-raymond  I like the message below "Deployment is live!". How about "No deployment found with commit $commit" instead of
"No resource found"?

2. Existing deployment, optional variable not set
```$ export GITHUB_SHA=24a97612d6158ba0adaff7564ead4e00c203ce0b
$ bash run.sh```
Authentication successful for user: rmminusrslash
The status is now ...
"running"
Deployment is live!
```

3. Use new feature: set optional env variable
```$ export GITHUB_SHA=non_existing_sha
$ export DEPLOY_SHA=24a97612d6158ba0adaff7564ead4e00c203ce0b
$ bash run.sh
bash run.sh
Authentication successful for user: rmminusrslash
The status is now ...
"running"
Deployment is live!
```
